### PR TITLE
NoTask - refactored index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var methods = ['get', 'post', 'put', 'patch', 'delete'],
+var methods = ['get', 'post', 'put', 'delete'],
     request = require('request').defaults({
         json: true
     });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var methods = ['get', 'post', 'put', 'delete'],
+var methods = ['get', 'post', 'put'],
     request = require('request').defaults({
         json: true
     });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var request = require('request');
+var methods = ['get', 'post', 'put', 'patch', 'delete'],
+    request = require('request').defaults({
+        json: true
+    });
 
 function Namely(options) {
     options = options || {};
@@ -8,7 +11,7 @@ function Namely(options) {
     this.accessToken = options.accessToken;
     this.apiVersion  = options.apiVersion || 'v1';
     this.companyName = options.companyName;
-    this.apiEndpoint = 'https://' + this.companyName + '.namely.com/api/' + this.apiVersion;
+    this.apiEndpoint = 'https://' + this.companyName + '.namely.com/api/' + this.apiVersion + '/';
 
     if (this.accessToken === undefined) {
         throw new Error('Namely must be initialized with an access token');
@@ -19,17 +22,19 @@ function Namely(options) {
     }
 }
 
-Namely.prototype.send = function (path, opts, cb) {
-    path = path + '.json';
-    opts = opts || {};
+Namely.prototype.send = function (method, path, opts, cb) {
+    path = this.apiEndpoint + path + '.json';
+
+    if (typeof opts === 'function') {
+        cb = opts;
+        opts = {};
+    }
 
     opts.headers = {
         authorization: 'Bearer ' + this.accessToken
     };
 
-    opts.json = true;
-
-    request(path, opts, function (error, response, body) {
+    request[method](path, opts, function (error, response, body) {
         if (error) {
             return cb(error);
         }
@@ -38,8 +43,14 @@ Namely.prototype.send = function (path, opts, cb) {
     });
 };
 
+methods.forEach(function (method) {
+    Namely.prototype[method] = function (path, opts, cb) {
+        return this.send(method, path, opts, cb);
+    };
+});
+
 Namely.prototype.profiles = function (opts, cb) {
-    this.send(this.apiEndpoint + '/profiles', opts, cb);
+    this.get('profiles', opts, cb);
 };
 
 module.exports = Namely;

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -16,7 +16,6 @@ describe('index', function () {
             request: {
                 delete: sandbox.stub(),
                 get: sandbox.stub(),
-                patch: sandbox.stub(),
                 post: sandbox.stub(),
                 put: sandbox.stub
             }
@@ -128,11 +127,10 @@ describe('index', function () {
         });
 
         describe('instance methods', function () {
-            it('creates get, post, put, patch and delete methods', function (){
+            it('creates get, post, put and delete methods', function (){
                 expect(namely.get).toBeDefined();
                 expect(namely.post).toBeDefined();
                 expect(namely.put).toBeDefined();
-                expect(namely.patch).toBeDefined();
                 expect(namely.delete).toBeDefined();
             });
 
@@ -201,7 +199,7 @@ describe('index', function () {
     });
 
     describe('request methods', function () {
-        describe('get, post, put, patch, delete methods', function () {
+        describe('get, post, put, delete methods', function () {
             var sendStub;
 
             beforeEach(function () {
@@ -249,20 +247,6 @@ describe('index', function () {
                 it('passes the correct arguments to send method', function() {
                     expect(sendStub.called).toEqual(true);
                     expect(sendStub.args[0][0]).toEqual('put');
-                    expect(sendStub.args[0][1]).toEqual('profiles/1');
-                    expect(sendStub.args[0][2]).toEqual({});
-                    expect(typeof(sendStub.args[0][3])).toEqual('function');
-                });
-            });
-
-            describe('patch', function () {
-                beforeEach(function () {
-                    namely.patch('profiles/1', {}, function () {});
-                });
-
-                it('passes the correct arguments to send method', function() {
-                    expect(sendStub.called).toEqual(true);
-                    expect(sendStub.args[0][0]).toEqual('patch');
                     expect(sendStub.args[0][1]).toEqual('profiles/1');
                     expect(sendStub.args[0][2]).toEqual({});
                     expect(typeof(sendStub.args[0][3])).toEqual('function');

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -268,23 +268,22 @@ describe('index', function () {
 
             it('sets authorization access token in headers before sending request', function () {
                 expect(sendSpy.calledOnce).toEqual(true);
-                expect(typeof(stubs.request.get.args[0][0])).toEqual('object');
-                expect(typeof(stubs.request.get.args[0][0].headers)).toEqual('object');
-                expect(stubs.request.get.args[0][0].headers.authorization).
+
+                expect(stubs.request.get.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                expect(typeof(stubs.request.get.args[0][1])).toEqual('object');
+                expect(typeof(stubs.request.get.args[0][1].headers)).toEqual('object');
+                expect(stubs.request.get.args[0][1].headers.authorization).
                     toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
             });
 
             it('calls request method passing correct arguments', function () {
                 expect(stubs.request.get.calledOnce).toEqual(true);
-                expect(stubs.request.get.args[0][0].uri).toEqual('https://companyName.namely.com/api/v1/profiles.json');
-                expect(stubs.request.get.args[0][0]).toEqual({
-                    headers: {
-                        authorization: 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                    },
-                    json: true,
-                    uri: 'https://companyName.namely.com/api/v1/profiles.json'
-                });
-                expect(typeof(stubs.request.get.args[0][1])).toEqual('function');
+                expect(stubs.request.get.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                expect(typeof(stubs.request.get.args[0][1])).toEqual('object');
+                expect(typeof(stubs.request.get.args[0][1].headers)).toEqual('object');
+                expect(stubs.request.get.args[0][1].headers.authorization).
+                    toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
+                expect(typeof(stubs.request.get.args[0][2])).toEqual('function');
             });
 
             describe('with no options', function () {
@@ -294,10 +293,12 @@ describe('index', function () {
 
                 it('sets the callback to be opts', function () {
                     expect(sendSpy.calledOnce).toEqual(true);
-                     expect(typeof(stubs.request.get.args[0][0])).toEqual('object');
-                    expect(typeof(stubs.request.get.args[0][0].headers)).toEqual('object');
-                    expect(stubs.request.get.args[0][0].headers.authorization).
+                    expect(stubs.request.get.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles.json')
+                    expect(typeof(stubs.request.get.args[0][1])).toEqual('object');
+                    expect(typeof(stubs.request.get.args[0][1].headers)).toEqual('object');
+                    expect(stubs.request.get.args[0][1].headers.authorization).
                         toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
+                    expect(typeof(stubs.request.get.args[0][2])).toEqual('function');
                 });
             });
 

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -13,7 +13,13 @@ describe('index', function () {
         sandbox = sinon.sandbox.create();
 
         stubs = {
-            request: sandbox.stub()
+            request: {
+                delete: sandbox.stub(),
+                get: sandbox.stub(),
+                patch: sandbox.stub(),
+                post: sandbox.stub(),
+                put: sandbox.stub
+            }
         };
 
         Namely = proxyquire('..', stubs);
@@ -60,7 +66,7 @@ describe('index', function () {
 
             it('sets the appropriate api endpoint based off of options passed', function () {
                 expect(namely.apiEndpoint).toBeDefined();
-                expect(namely.apiEndpoint).toEqual('https://companyName.namely.com/api/v1');
+                expect(namely.apiEndpoint).toEqual('https://companyName.namely.com/api/v1/');
             });
         });
 
@@ -91,7 +97,7 @@ describe('index', function () {
 
             it('sets the appropriate api endpoint based off of options passed', function () {
                 expect(namely.apiEndpoint).toBeDefined();
-                expect(namely.apiEndpoint).toEqual('https://testing.namely.com/api/v2');
+                expect(namely.apiEndpoint).toEqual('https://testing.namely.com/api/v2/');
             });
         });
 
@@ -120,11 +126,29 @@ describe('index', function () {
                 }).toThrow('Namely must be initialized with an access token');
             });
         });
+
+        describe('instance methods', function () {
+            it('creates get, post, put, patch and delete methods', function (){
+                expect(namely.get).toBeDefined();
+                expect(namely.post).toBeDefined();
+                expect(namely.put).toBeDefined();
+                expect(namely.patch).toBeDefined();
+                expect(namely.delete).toBeDefined();
+            });
+
+            it('has a send method', function () {
+                expect(namely.send).toBeDefined();
+            });
+
+            it('has api methods', function() {
+                expect(namely.profiles).toBeDefined();
+            });
+        });
     });
 
     describe('profiles', function () {
-        var profileSpy,
-            sendStub;
+        var getStub,
+            profileSpy;
 
         beforeEach(function () {
             namely = new Namely({
@@ -132,8 +156,8 @@ describe('index', function () {
                 companyName: 'companyName'
             });
 
+            getStub = sandbox.stub(namely, 'get');
             profileSpy = sandbox.spy(namely, 'profiles');
-            sendStub   = sandbox.stub(namely, 'send');
         });
 
         describe('with no options', function () {
@@ -147,10 +171,10 @@ describe('index', function () {
             });
 
             it('it calls send and passes the correct arguments', function () {
-                expect(sendStub.calledOnce).toEqual(true);
-                expect(sendStub.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles');
-                expect(sendStub.args[0][1]).toEqual(undefined);
-                expect(sendStub.args[0][2]).toEqual(undefined);
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('profiles');
+                expect(getStub.args[0][1]).toEqual(undefined);
+                expect(getStub.args[0][2]).toEqual(undefined);
             });
         });
 
@@ -168,85 +192,206 @@ describe('index', function () {
             });
 
             it('it calls send and passes the correct arguments', function () {
-                expect(sendStub.calledOnce).toEqual(true);
-                expect(sendStub.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles');
-                expect(sendStub.args[0][1]).toEqual({limit: 100, after: '12345678790'});
-                expect(sendStub.args[0][2]).toEqual(undefined);
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('profiles');
+                expect(getStub.args[0][1]).toEqual({limit: 100, after: '12345678790'});
+                expect(getStub.args[0][2]).toEqual(undefined);
             });
         });
     });
 
-    describe('send', function () {
-        var sendSpy;
-
-        beforeEach(function () {
-            namely = new Namely({
-                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                companyName: 'companyName'
-            });
-
-            sendSpy = sandbox.spy(namely, 'send');
-
-            namely.profiles();
-        });
-
-        it('sets authorization access token in headers before sending request', function () {
-            expect(sendSpy.calledOnce).toEqual(true);
-            expect(typeof(stubs.request.args[0][1])).toEqual('object');
-            expect(typeof(stubs.request.args[0][1].headers)).toEqual('object');
-            expect(stubs.request.args[0][1].headers.authorization).toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
-        });
-
-        it('appends .json to the url path before sending request', function () {
-            expect(sendSpy.calledOnce).toEqual(true);
-            expect(typeof(stubs.request.args[0][1])).toEqual('object');
-            expect(stubs.request.args[0][1].json).toEqual(true);
-        });
-
-        it('calls request passing correct arguments', function () {
-            expect(stubs.request.calledOnce).toEqual(true);
-            expect(stubs.request.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles.json');
-            expect(stubs.request.args[0][1]).toEqual({
-                headers: {
-                    authorization: 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                },
-                json: true
-            });
-            expect(typeof(stubs.request.args[0][2])).toEqual('function');
-        });
-
-        describe('callback', function () {
-            var callbackSpy;
+    describe('request methods', function () {
+        describe('get, post, put, patch, delete methods', function () {
+            var sendStub;
 
             beforeEach(function () {
-                callbackSpy = sandbox.spy();
+                namely = new Namely({
+                    accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                    companyName: 'companyName'
+                });
+
+                sendStub = sandbox.stub(namely, 'send');
             });
 
-            describe('error', function () {
+            describe('get', function () {
                 beforeEach(function () {
-                    stubs = {
-                        request: sandbox.stub().yields('Fake Error', {}, {})
-                    };
+                    namely.get('profiles', {}, function () {});
+                });
 
-                    Namely = proxyquire('..', stubs);
+                it('passes the correct arguments to send method', function() {
+                    expect(sendStub.called).toEqual(true);
+                    expect(sendStub.args[0][0]).toEqual('get');
+                    expect(sendStub.args[0][1]).toEqual('profiles');
+                    expect(sendStub.args[0][2]).toEqual({});
+                    expect(typeof(sendStub.args[0][3])).toEqual('function');
+                });
+            });
 
-                    namely = new Namely({
-                        accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                        companyName: 'companyName'
+            describe('post', function () {
+                beforeEach(function () {
+                    namely.post('profiles', {}, function () {});
+                });
+
+                it('passes the correct arguments to send method', function() {
+                    expect(sendStub.called).toEqual(true);
+                    expect(sendStub.args[0][0]).toEqual('post');
+                    expect(sendStub.args[0][1]).toEqual('profiles');
+                    expect(sendStub.args[0][2]).toEqual({});
+                    expect(typeof(sendStub.args[0][3])).toEqual('function');
+                });
+            });
+
+            describe('put', function () {
+                beforeEach(function () {
+                    namely.put('profiles/1', {}, function () {});
+                });
+
+                it('passes the correct arguments to send method', function() {
+                    expect(sendStub.called).toEqual(true);
+                    expect(sendStub.args[0][0]).toEqual('put');
+                    expect(sendStub.args[0][1]).toEqual('profiles/1');
+                    expect(sendStub.args[0][2]).toEqual({});
+                    expect(typeof(sendStub.args[0][3])).toEqual('function');
+                });
+            });
+
+            describe('patch', function () {
+                beforeEach(function () {
+                    namely.patch('profiles/1', {}, function () {});
+                });
+
+                it('passes the correct arguments to send method', function() {
+                    expect(sendStub.called).toEqual(true);
+                    expect(sendStub.args[0][0]).toEqual('patch');
+                    expect(sendStub.args[0][1]).toEqual('profiles/1');
+                    expect(sendStub.args[0][2]).toEqual({});
+                    expect(typeof(sendStub.args[0][3])).toEqual('function');
+                });
+            });
+
+            describe('delete', function () {
+                beforeEach(function () {
+                    namely.delete('profiles/1', {}, function () {});
+                });
+
+                it('passes the correct arguments to send method', function() {
+                    expect(sendStub.called).toEqual(true);
+                    expect(sendStub.args[0][0]).toEqual('delete');
+                    expect(sendStub.args[0][1]).toEqual('profiles/1');
+                    expect(sendStub.args[0][2]).toEqual({});
+                    expect(typeof(sendStub.args[0][3])).toEqual('function');
+                });
+            });
+        });
+
+        describe('send', function () {
+            var sendSpy;
+
+            beforeEach(function () {
+                namely = new Namely({
+                    accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                    companyName: 'companyName'
+                });
+
+                sendSpy = sandbox.spy(namely, 'send');
+
+                namely.profiles({}, function () {});
+            });
+
+            it('sets authorization access token in headers before sending request', function () {
+                expect(sendSpy.calledOnce).toEqual(true);
+                expect(typeof(stubs.request.get.args[0][0])).toEqual('object');
+                expect(typeof(stubs.request.get.args[0][0].headers)).toEqual('object');
+                expect(stubs.request.get.args[0][0].headers.authorization).
+                    toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
+            });
+
+            it('calls request method passing correct arguments', function () {
+                expect(stubs.request.get.calledOnce).toEqual(true);
+                expect(stubs.request.get.args[0][0].uri).toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                expect(stubs.request.get.args[0][0]).toEqual({
+                    headers: {
+                        authorization: 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                    },
+                    json: true,
+                    uri: 'https://companyName.namely.com/api/v1/profiles.json'
+                });
+                expect(typeof(stubs.request.get.args[0][1])).toEqual('function');
+            });
+
+            describe('with no options', function () {
+                before(function () {
+                    namely.profiles(function () {});
+                });
+
+                it('sets the callback to be opts', function () {
+                    expect(sendSpy.calledOnce).toEqual(true);
+                     expect(typeof(stubs.request.get.args[0][0])).toEqual('object');
+                    expect(typeof(stubs.request.get.args[0][0].headers)).toEqual('object');
+                    expect(stubs.request.get.args[0][0].headers.authorization).
+                        toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
+                });
+            });
+
+            describe('callback', function () {
+                var callbackSpy;
+
+                beforeEach(function () {
+                    callbackSpy = sandbox.spy();
+                });
+
+                describe('error', function () {
+                    beforeEach(function () {
+                        stubs = {
+                            request: {
+                                get: sandbox.stub().yields('Fake Error', {}, {})
+                            }
+                        };
+
+                        Namely = proxyquire('..', stubs);
+
+                        namely = new Namely({
+                            accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                            companyName: 'companyName'
+                        });
+                    });
+
+                    it('calls callback with error if error returned', function () {
+                        namely.profiles({}, callbackSpy);
+                        expect(callbackSpy.calledOnce).toEqual(true);
+                        expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
                     });
                 });
 
-                it('calls callback with error if error returned', function () {
-                    namely.profiles({}, callbackSpy);
-                    expect(callbackSpy.calledOnce).toEqual(true);
-                    expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
-                });
-            });
+                describe('no error', function () {
+                    beforeEach(function () {
+                        stubs = {
+                            request: {
+                                get: sandbox.stub().yields(null, {
+                                    a: '1',
+                                    b: '2',
+                                    c: '3'
+                                }, {
+                                    d: '4',
+                                    e: '5',
+                                    f: '6'
+                                })
+                            }
+                        };
 
-            describe('no error', function () {
-                beforeEach(function () {
-                    stubs = {
-                        request: sandbox.stub().yields(null, {
+                        Namely = proxyquire('..', stubs);
+
+                        namely = new Namely({
+                            accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                            companyName: 'companyName'
+                        });
+                    });
+
+                    it('calls callback with results if no error returned', function () {
+                        namely.profiles({}, callbackSpy);
+
+                        expect(callbackSpy.calledOnce).toEqual(true);
+                        expect(callbackSpy.calledWith(null, {
                             a: '1',
                             b: '2',
                             c: '3'
@@ -254,30 +399,8 @@ describe('index', function () {
                             d: '4',
                             e: '5',
                             f: '6'
-                        })
-                    };
-
-                    Namely = proxyquire('..', stubs);
-
-                    namely = new Namely({
-                        accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                        companyName: 'companyName'
+                        })).toEqual(true);
                     });
-                });
-
-                it('calls callback with error if error returned', function () {
-                    namely.profiles({}, callbackSpy);
-
-                    expect(callbackSpy.calledOnce).toEqual(true);
-                    expect(callbackSpy.calledWith(null, {
-                        a: '1',
-                        b: '2',
-                        c: '3'
-                    }, {
-                        d: '4',
-                        e: '5',
-                        f: '6'
-                    })).toEqual(true);
                 });
             });
         });

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -14,7 +14,6 @@ describe('index', function () {
 
         stubs = {
             request: {
-                delete: sandbox.stub(),
                 get: sandbox.stub(),
                 post: sandbox.stub(),
                 put: sandbox.stub
@@ -127,11 +126,10 @@ describe('index', function () {
         });
 
         describe('instance methods', function () {
-            it('creates get, post, put and delete methods', function (){
+            it('creates get, post, and put methods', function (){
                 expect(namely.get).toBeDefined();
                 expect(namely.post).toBeDefined();
                 expect(namely.put).toBeDefined();
-                expect(namely.delete).toBeDefined();
             });
 
             it('has a send method', function () {
@@ -199,7 +197,7 @@ describe('index', function () {
     });
 
     describe('request methods', function () {
-        describe('get, post, put, delete methods', function () {
+        describe('get, post, and put methods', function () {
             var sendStub;
 
             beforeEach(function () {
@@ -247,20 +245,6 @@ describe('index', function () {
                 it('passes the correct arguments to send method', function() {
                     expect(sendStub.called).toEqual(true);
                     expect(sendStub.args[0][0]).toEqual('put');
-                    expect(sendStub.args[0][1]).toEqual('profiles/1');
-                    expect(sendStub.args[0][2]).toEqual({});
-                    expect(typeof(sendStub.args[0][3])).toEqual('function');
-                });
-            });
-
-            describe('delete', function () {
-                beforeEach(function () {
-                    namely.delete('profiles/1', {}, function () {});
-                });
-
-                it('passes the correct arguments to send method', function() {
-                    expect(sendStub.called).toEqual(true);
-                    expect(sendStub.args[0][0]).toEqual('delete');
                     expect(sendStub.args[0][1]).toEqual('profiles/1');
                     expect(sendStub.args[0][2]).toEqual({});
                     expect(typeof(sendStub.args[0][3])).toEqual('function');


### PR DESCRIPTION
## Changes

Refactored index.js with the following:
- Use `request.defaults()` to set `json: true` globally
- Updated `send` method to check if `opts` is function and if so set as callback
- Added `get`, `post`, and `put` request methods to create bridge between high level api requests and low level `send` function
- Now set full apiEndpoint path in `send` function
- Updated existing tests and fixed title
