### PR TITLE
NoTask - refactored code and added api endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var request = require('request');
+var methods = ['get', 'post', 'put'],
+    request = require('request').defaults({
+        json: true
+    });
 
 function Namely(options) {
     options = options || {};
@@ -19,27 +22,143 @@ function Namely(options) {
     }
 }
 
-Namely.prototype.send = function (path, opts, cb) {
-    path = path + '.json';
-    opts = opts || {};
-
-    opts.headers = {
-        authorization: 'Bearer ' + this.accessToken
-    };
-
-    opts.json = true;
-
-    request(path, opts, function (error, response, body) {
+function send (method, path, opts, cb) {
+    request[method](path, opts, function (error, response, body) {
         if (error) {
             return cb(error);
         }
 
         cb(null, response, body);
     });
-};
+}
+
+methods.forEach(function (method) {
+    Namely.prototype[method] = function (path, opts, cb) {
+        if (typeof opts === 'function') {
+            cb = opts;
+            opts = {};
+        }
+
+        path = this.apiEndpoint + path + '.json';
+
+        opts.headers = {
+            authorization: 'Bearer ' + this.accessToken
+        };
+
+        return send(method, path, opts, cb);
+    };
+});
 
 Namely.prototype.profiles = function (opts, cb) {
-    this.send(this.apiEndpoint + '/profiles', opts, cb);
+    this.get('/profiles', opts, cb);
+};
+
+Namely.prototype.profile = function (id, opts, cb) {
+    this.get('/profiles/' + id, opts, cb);
+};
+
+Namely.prototype.createProfile = function (opts, cb) {
+    this.post('/profiles', opts, cb);
+};
+
+Namely.prototype.updateProfile = function (id, opts, cb) {
+    this.put('/profiles/' + id, opts, cb);
+};
+
+Namely.prototype.me = function (opts, cb) {
+    this.get('/profiles/me', opts, cb);
+};
+
+Namely.prototype.fields = function (opts, cb) {
+    this.get('/profiles/fields', opts, cb);
+};
+
+Namely.prototype.createField = function (opts, cb) {
+    this.post('/profiles/fields', opts, cb);
+};
+
+Namely.prototype.updateField = function (id, opts, cb) {
+    this.put('/profiles/fields/' + id, opts, cb);
+};
+
+Namely.prototype.sections = function (opts, cb) {
+    this.get('/profiles/fields/sections', opts, cb);
+};
+
+Namely.prototype.section = function (id, opts, cb) {
+    this.get('/profiles/fields/sections/' + id, opts, cb);
+};
+
+Namely.prototype.createSection = function (opts, cb) {
+    this.post('/profiles/fields/sections', opts, cb);
+};
+
+Namely.prototype.updateSection = function (id, opts, cb) {
+    this.put('/profiles/fields/sections/' + id, opts, cb);
+};
+
+Namely.prototype.createFile = function (opts, cb) {
+    this.post('/files', opts, cb);
+};
+
+Namely.prototype.events = function (opts, cb) {
+    this.get('/events', opts, cb);
+};
+
+Namely.prototype.event = function (id, opts, cb) {
+    this.get('/events/' + id, opts, cb);
+};
+
+Namely.prototype.createEvent = function (opts, cb) {
+    this.post('/events', opts, cb);
+};
+
+Namely.prototype.updateEvent = function (id, opts, cb) {
+    this.put('/events/' + id, opts, cb);
+};
+
+Namely.prototype.currencyTypes = function (opts, cb) {
+    this.get('/currency_types', opts, cb);
+};
+
+Namely.prototype.countries = function (opts, cb) {
+    this.get('/countries', opts, cb);
+};
+
+Namely.prototype.country = function (id, opts, cb) {
+    this.get('/countries/' + id, opts, cb);
+};
+
+Namely.prototype.jobTitles = function (opts, cb) {
+    this.get('/job_titles', opts, cb);
+};
+
+Namely.prototype.jobTitle = function (id, opts, cb) {
+    this.get('/job_titles/' + id, opts, cb);
+};
+
+Namely.prototype.createJobTitle = function (opts, cb) {
+    this.post('/job_titles', opts, cb);
+};
+
+Namely.prototype.updateJobTitle = function (id, opts, cb) {
+    this.put('/job_titles/' + id, opts, cb);
+};
+
+Namely.prototype.jobTiers = function (opts, cb) {
+    this.get('/job_tiers', opts, cb);
+};
+
+Namely.prototype.jobTier = function (id, opts, cb) {
+    this.get('/job_tiers/' + id, opts, cb);
+};
+
+Namely.prototype.createJobTier = function (opts, cb) {
+    this.post('/job_tiers', opts, cb);
+};
+
+Namely.prototype.updateJobTier = function (id, opts, cb) {
+    this.put('/job_tiers/' + id, opts, cb);
 };
 
 module.exports = Namely;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@gite.brandwatch.com:jonathan/namely.git"
+    "url": "https://github.com/jonathanchrisp/namely"
   },
   "author": "Jonathan Chrisp",
   "license": "MIT",

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -1,3 +1,5 @@
+// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+
 'use strict';
 
 var proxyquire = require('proxyquire'),
@@ -13,7 +15,11 @@ describe('index', function () {
         sandbox = sinon.sandbox.create();
 
         stubs = {
-            request: sandbox.stub()
+            request: {
+                get: sandbox.stub(),
+                post: sandbox.stub(),
+                put: sandbox.stub()
+            }
         };
 
         Namely = proxyquire('..', stubs);
@@ -120,11 +126,458 @@ describe('index', function () {
                 }).toThrow('Namely must be initialized with an access token');
             });
         });
+
+        describe('instance methods', function () {
+            it('creates get, post, and put methods', function () {
+                expect(namely.get).toBeDefined();
+                expect(namely.post).toBeDefined();
+                expect(namely.put).toBeDefined();
+            });
+
+            it('has api methods', function () {
+                expect(namely.profiles).toBeDefined();
+            });
+        });
+    });
+
+    describe('request methods', function () {
+        describe('get, post, and put methods', function () {
+            beforeEach(function () {
+                namely = new Namely({
+                    accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                    companyName: 'companyName'
+                });
+            });
+
+            describe('get', function () {
+                var getStub;
+
+                describe('arguments', function () {
+                    beforeEach(function () {
+                        getStub = sandbox.stub(namely, 'get');
+
+                        namely.get('/profiles', {}, function () {});
+                    });
+
+                    it('gets passed the correct arguments', function () {
+                        expect(getStub.called).toEqual(true);
+                        expect(getStub.args[0][0]).toEqual('/profiles');
+                        expect(getStub.args[0][1]).toEqual({});
+                        expect(typeof(getStub.args[0][2])).toEqual('function');
+                    });
+                });
+
+                describe('request call', function () {
+                    describe('with options', function () {
+                        beforeEach(function () {
+                            namely.get('/profiles', {}, function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.get.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.get.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.get.args[0][2])).toEqual('function');
+                        });
+                    });
+
+                    describe('without options', function () {
+                        beforeEach(function () {
+                            namely.get('/profiles', function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.get.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.get.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.get.args[0][2])).toEqual('function');
+                        });
+                    });
+                });
+
+                describe('callback', function () {
+                    var callbackSpy;
+
+                    beforeEach(function () {
+                        callbackSpy = sandbox.spy();
+                    });
+
+                    describe('error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    get: sandbox.stub().yields('Fake Error', {}, {})
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with error if error returned', function () {
+                            namely.get('/profiles', {}, callbackSpy);
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
+                        });
+                    });
+
+                    describe('no error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    get: sandbox.stub().yields(null, {
+                                        a: '1',
+                                        b: '2',
+                                        c: '3'
+                                    }, {
+                                        d: '4',
+                                        e: '5',
+                                        f: '6'
+                                    })
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with results if no error returned', function () {
+                            namely.get('/profiles', {}, callbackSpy);
+
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith(null, {
+                                a: '1',
+                                b: '2',
+                                c: '3'
+                            }, {
+                                d: '4',
+                                e: '5',
+                                f: '6'
+                            })).toEqual(true);
+                        });
+                    });
+                });
+            });
+
+            describe('post', function () {
+                var postStub;
+
+                beforeEach(function () {
+                    namely.post('/profiles', {}, function () {});
+                });
+
+                describe('arguments', function () {
+                    beforeEach(function () {
+                        postStub = sandbox.stub(namely, 'post');
+
+                        namely.post('/profiles', {}, function () {});
+                    });
+
+                    it('gets passed the correct arguments', function () {
+                        expect(postStub.called).toEqual(true);
+                        expect(postStub.args[0][0]).toEqual('/profiles');
+                        expect(postStub.args[0][1]).toEqual({});
+                        expect(typeof(postStub.args[0][2])).toEqual('function');
+                    });
+                });
+
+                describe('request call', function () {
+                    describe('with options', function () {
+                        beforeEach(function () {
+                            namely.post('/profiles', {}, function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.post.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.post.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.post.args[0][2])).toEqual('function');
+                        });
+                    });
+
+                    describe('with no options', function () {
+                        beforeEach(function () {
+                            namely.post('/profiles', function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.post.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.post.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.post.args[0][2])).toEqual('function');
+                        });
+                    });
+                });
+
+                describe('callback', function () {
+                    var callbackSpy;
+
+                    beforeEach(function () {
+                        callbackSpy = sandbox.spy();
+                    });
+
+                    describe('error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    post: sandbox.stub().yields('Fake Error', {}, {})
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with error if error returned', function () {
+                            namely.post('/profiles', {}, callbackSpy);
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
+                        });
+                    });
+
+                    describe('no error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    post: sandbox.stub().yields(null, {
+                                        a: '1',
+                                        b: '2',
+                                        c: '3'
+                                    }, {
+                                        d: '4',
+                                        e: '5',
+                                        f: '6'
+                                    })
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with results if no error returned', function () {
+                            namely.post('/profiles', {}, callbackSpy);
+
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith(null, {
+                                a: '1',
+                                b: '2',
+                                c: '3'
+                            }, {
+                                d: '4',
+                                e: '5',
+                                f: '6'
+                            })).toEqual(true);
+                        });
+                    });
+                });
+            });
+
+            describe('put', function () {
+                var putStub;
+
+                beforeEach(function () {
+                    namely.put('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {}, function () {});
+                });
+
+                describe('arguments', function () {
+                    beforeEach(function () {
+                        putStub = sandbox.stub(namely, 'put');
+
+                        namely.put('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {}, function () {});
+                    });
+
+                    it('gets passed the correct arguments', function () {
+                        expect(putStub.called).toEqual(true);
+                        expect(putStub.args[0][0]).toEqual('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                        expect(putStub.args[0][1]).toEqual({});
+                        expect(typeof(putStub.args[0][2])).toEqual('function');
+                    });
+                });
+
+                describe('request call', function () {
+                    describe('with options', function () {
+                        beforeEach(function () {
+                            namely.put('/profiles', {}, function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.put.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles/' +
+                                    'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.put.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.put.args[0][2])).toEqual('function');
+                        });
+                    });
+
+                    describe('with no options', function () {
+                        beforeEach(function () {
+                            namely.put('/profiles', function () {});
+                        });
+
+                        it('gets passed the correct path', function () {
+                            expect(stubs.request.put.args[0][0]).
+                                toEqual('https://companyName.namely.com/api/v1/profiles/' +
+                                    'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96.json');
+                        });
+
+                        it('gets passed the correct options', function () {
+                            expect(stubs.request.put.args[0][1]).toEqual({
+                                'headers': {
+                                    'authorization': 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT'
+                                }
+                            });
+                        });
+
+                        it('gets passed a callback function', function () {
+                            expect(typeof(stubs.request.put.args[0][2])).toEqual('function');
+                        });
+                    });
+                });
+
+                describe('callback', function () {
+                    var callbackSpy;
+
+                    beforeEach(function () {
+                        callbackSpy = sandbox.spy();
+                    });
+
+                    describe('error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    put: sandbox.stub().yields('Fake Error', {}, {})
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with error if error returned', function () {
+                            namely.put('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {}, callbackSpy);
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
+                        });
+                    });
+
+                    describe('no error', function () {
+                        beforeEach(function () {
+                            stubs = {
+                                request: {
+                                    put: sandbox.stub().yields(null, {
+                                        a: '1',
+                                        b: '2',
+                                        c: '3'
+                                    }, {
+                                        d: '4',
+                                        e: '5',
+                                        f: '6'
+                                    })
+                                }
+                            };
+
+                            Namely = proxyquire('..', stubs);
+
+                            namely = new Namely({
+                                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                                companyName: 'companyName'
+                            });
+                        });
+
+                        it('calls callback with results if no error returned', function () {
+                            namely.put('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {}, callbackSpy);
+
+                            expect(callbackSpy.calledOnce).toEqual(true);
+                            expect(callbackSpy.calledWith(null, {
+                                a: '1',
+                                b: '2',
+                                c: '3'
+                            }, {
+                                d: '4',
+                                e: '5',
+                                f: '6'
+                            })).toEqual(true);
+                        });
+                    });
+                });
+            });
+        });
     });
 
     describe('profiles', function () {
-        var profileSpy,
-            sendStub;
+        var getStub,
+            profilesSpy;
 
         beforeEach(function () {
             namely = new Namely({
@@ -132,52 +585,65 @@ describe('index', function () {
                 companyName: 'companyName'
             });
 
-            profileSpy = sandbox.spy(namely, 'profiles');
-            sendStub   = sandbox.stub(namely, 'send');
+            getStub = sandbox.stub(namely, 'get');
+            profilesSpy = sandbox.spy(namely, 'profiles');
         });
 
         describe('with no options', function () {
             beforeEach(function () {
-                namely.profiles();
+                namely.profiles(function () {});
             });
 
             it('it calls profiles and passes the correct arguments', function () {
-                expect(profileSpy.calledOnce).toEqual(true);
-                expect(profileSpy.args[0][0]).toEqual(undefined);
+                expect(profilesSpy.calledOnce).toEqual(true);
+                expect(typeof(profilesSpy.args[0][0])).toEqual('function');
             });
 
-            it('it calls send and passes the correct arguments', function () {
-                expect(sendStub.calledOnce).toEqual(true);
-                expect(sendStub.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles');
-                expect(sendStub.args[0][1]).toEqual(undefined);
-                expect(sendStub.args[0][2]).toEqual(undefined);
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
             });
         });
 
         describe('with options', function () {
             beforeEach(function () {
                 namely.profiles({
-                    limit: 100,
-                    after: '12345678790'
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
+                }, function () {});
+            });
+
+            it('it calls profiles and passes the correct arguments', function () {
+                expect(profilesSpy.calledOnce).toEqual(true);
+                expect(profilesSpy.args[0][0]).toEqual({
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
                 });
             });
 
-            it('it calls send and passes the correct arguments', function () {
-                expect(profileSpy.calledOnce).toEqual(true);
-                expect(profileSpy.args[0][0]).toEqual({limit: 100, after: '12345678790'});
-            });
-
-            it('it calls send and passes the correct arguments', function () {
-                expect(sendStub.calledOnce).toEqual(true);
-                expect(sendStub.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles');
-                expect(sendStub.args[0][1]).toEqual({limit: 100, after: '12345678790'});
-                expect(sendStub.args[0][2]).toEqual(undefined);
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles');
+                expect(getStub.args[0][1]).toEqual({
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
+                });
+                expect(typeof(getStub.args[0][2])).toEqual('function');
             });
         });
     });
 
-    describe('send', function () {
-        var sendSpy;
+    describe('profile', function () {
+        var getStub,
+            profileSpy;
 
         beforeEach(function () {
             namely = new Namely({
@@ -185,100 +651,1242 @@ describe('index', function () {
                 companyName: 'companyName'
             });
 
-            sendSpy = sandbox.spy(namely, 'send');
-
-            namely.profiles();
+            getStub = sandbox.stub(namely, 'get');
+            profileSpy = sandbox.spy(namely, 'profile');
         });
 
-        it('sets authorization access token in headers before sending request', function () {
-            expect(sendSpy.calledOnce).toEqual(true);
-            expect(typeof(stubs.request.args[0][1])).toEqual('object');
-            expect(typeof(stubs.request.args[0][1].headers)).toEqual('object');
-            expect(stubs.request.args[0][1].headers.authorization).toEqual('Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT');
-        });
-
-        it('appends .json to the url path before sending request', function () {
-            expect(sendSpy.calledOnce).toEqual(true);
-            expect(typeof(stubs.request.args[0][1])).toEqual('object');
-            expect(stubs.request.args[0][1].json).toEqual(true);
-        });
-
-        it('calls request passing correct arguments', function () {
-            expect(stubs.request.calledOnce).toEqual(true);
-            expect(stubs.request.args[0][0]).toEqual('https://companyName.namely.com/api/v1/profiles.json');
-            expect(stubs.request.args[0][1]).toEqual({
-                headers: {
-                    authorization: 'Bearer UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                },
-                json: true
-            });
-            expect(typeof(stubs.request.args[0][2])).toEqual('function');
-        });
-
-        describe('callback', function () {
-            var callbackSpy;
-
+        describe('with no options', function () {
             beforeEach(function () {
-                callbackSpy = sandbox.spy();
+                namely.profile('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
             });
 
-            describe('error', function () {
-                beforeEach(function () {
-                    stubs = {
-                        request: sandbox.stub().yields('Fake Error', {}, {})
-                    };
+            it('it calls profile and passes the correct arguments', function () {
+                expect(profileSpy.calledOnce).toEqual(true);
+                expect(profileSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(profileSpy.args[0][1])).toEqual('function');
+            });
 
-                    Namely = proxyquire('..', stubs);
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
 
-                    namely = new Namely({
-                        accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                        companyName: 'companyName'
-                    });
+    describe('createProfile', function () {
+        var postStub,
+            createProfileSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createProfileSpy = sandbox.spy(namely, 'createProfile');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createProfile({
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
+                }, function () {});
+            });
+
+            it('it calls createProfile and passes the correct arguments', function () {
+                expect(createProfileSpy.calledOnce).toEqual(true);
+                expect(createProfileSpy.args[0][0]).toEqual({
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
                 });
+                expect(typeof(createProfileSpy.args[0][1])).toEqual('function');
+            });
 
-                it('calls callback with error if error returned', function () {
-                    namely.profiles({}, callbackSpy);
-                    expect(callbackSpy.calledOnce).toEqual(true);
-                    expect(callbackSpy.calledWith('Fake Error')).toEqual(true);
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/profiles');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateProfile', function () {
+        var putStub,
+            updateProfileSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updateProfileSpy = sandbox.spy(namely, 'updateProfile');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateProfile('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateProfile and passes the correct arguments', function () {
+                expect(updateProfileSpy.calledOnce).toEqual(true);
+                expect(updateProfileSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updateProfileSpy.args[0][1]).toEqual({
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
+                });
+                expect(typeof(updateProfileSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/profiles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        first_name: 'first name',
+                        last_name: 'last name',
+                        email: 'email@address.com',
+                        user_status: 'active',
+                        start_date: '2015-03-27',
+                        end_date: '2015-03-28',
+                        departure_date: '2015-03-28',
+                        gender: 'Male',
+                        marital_status: 'Single',
+                        job_title: 'CEO',
+                        resume: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        image: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        office: '123 Office Address',
+                        home: '123 Home Address'
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('me', function () {
+        var getStub,
+            meSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            meSpy = sandbox.spy(namely, 'me');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.me(function () {});
+            });
+
+            it('it calls me and passes the correct arguments', function () {
+                expect(meSpy.calledOnce).toEqual(true);
+                expect(typeof(meSpy.args[0][0])).toEqual('function');
+                expect(meSpy.args[0][1]).toEqual(undefined);
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles/me');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('fields', function () {
+        var getStub,
+            fieldsSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            fieldsSpy = sandbox.spy(namely, 'fields');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.fields(function () {});
+            });
+
+            it('it calls fields and passes the correct arguments', function () {
+                expect(fieldsSpy.calledOnce).toEqual(true);
+                expect(typeof(fieldsSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles/fields');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('createField', function () {
+        var postStub,
+            createFieldSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createFieldSpy = sandbox.spy(namely, 'createField');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createField({
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                }, function () {});
+            });
+
+            it('it calls createField and passes the correct arguments', function () {
+                expect(createFieldSpy.calledOnce).toEqual(true);
+                expect(createFieldSpy.args[0][0]).toEqual({
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                });
+                expect(typeof(createFieldSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/profiles/fields');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateField', function () {
+        var putStub,
+            updateFieldSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updateFieldSpy = sandbox.spy(namely, 'updateField');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateField('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateField and passes the correct arguments', function () {
+                expect(updateFieldSpy.calledOnce).toEqual(true);
+                expect(updateFieldSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updateFieldSpy.args[0][1]).toEqual({
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                });
+                expect(typeof(updateFieldSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/profiles/fields/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        section_id: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        title: 'title',
+                        type: 'Text',
+                        choices: []
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('sections', function () {
+        var getStub,
+            sectionsSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            sectionsSpy = sandbox.spy(namely, 'sections');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.sections(function () {});
+            });
+
+            it('it calls sections and passes the correct arguments', function () {
+                expect(sectionsSpy.calledOnce).toEqual(true);
+                expect(typeof(sectionsSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles/fields/sections');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('section', function () {
+        var getStub,
+            sectionSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            sectionSpy = sandbox.spy(namely, 'section');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.section('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
+            });
+
+            it('it calls section and passes the correct arguments', function () {
+                expect(sectionSpy.calledOnce).toEqual(true);
+                expect(sectionSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(sectionSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/profiles/fields/sections/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('createSection', function () {
+        var postStub,
+            createSectionSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createSectionSpy = sandbox.spy(namely, 'createSection');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createSection({
+                    body: {
+                        title: 'section title'
+                    }
+                }, function () {});
+            });
+
+            it('it calls createSection and passes the correct arguments', function () {
+                expect(createSectionSpy.calledOnce).toEqual(true);
+                expect(createSectionSpy.args[0][0]).toEqual({
+                    body: {
+                        title: 'section title'
+                    }
+                });
+                expect(typeof(createSectionSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/profiles/fields/sections');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'section title'
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateSection', function () {
+        var putStub,
+            updatedSectionSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updatedSectionSpy = sandbox.spy(namely, 'updateSection');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateSection('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        title: 'updated section title'
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateSection and passes the correct arguments', function () {
+                expect(updatedSectionSpy.calledOnce).toEqual(true);
+                expect(updatedSectionSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updatedSectionSpy.args[0][1]).toEqual({
+                    body: {
+                        title: 'updated section title'
+                    }
+                });
+                expect(typeof(updatedSectionSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/profiles/fields/sections/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'updated section title'
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('createFile', function () {
+        var postStub,
+            createFileSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createFileSpy = sandbox.spy(namely, 'createFile');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createFile({
+                    body: {
+                        id:'d5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        filename:'file.jpg',
+                        mime_type:'image/jpeg',
+                        original:'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/download',
+                        thumbs:{
+                            '75x75':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75.jpg',
+                            '75x75c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75c.jpg',
+                            '150x150':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150.jpg',
+                            '150x150c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150c.jpg',
+                            '300x300':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/300x300.jpg',
+                            '450x450':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/450x450.jpg',
+                            '800x800':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/800x800.jpg'
+                        }
+                    }
+                }, function () {});
+            });
+
+            it('it calls createFile and passes the correct arguments', function () {
+                expect(createFileSpy.calledOnce).toEqual(true);
+                expect(createFileSpy.args[0][0]).toEqual({
+                    body: {
+                        id:'d5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        filename:'file.jpg',
+                        mime_type:'image/jpeg',
+                        original:'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/download',
+                        thumbs:{
+                            '75x75':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75.jpg',
+                            '75x75c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75c.jpg',
+                            '150x150':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150.jpg',
+                            '150x150c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150c.jpg',
+                            '300x300':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/300x300.jpg',
+                            '450x450':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/450x450.jpg',
+                            '800x800':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/800x800.jpg'
+                        }
+                    }
+                });
+                expect(typeof(createFileSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/files');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        id:'d5b3cb26-8b17-4f18-9af7-f678fa6a2e96',
+                        filename:'file.jpg',
+                        mime_type:'image/jpeg',
+                        original:'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/download',
+                        thumbs:{
+                            '75x75':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75.jpg',
+                            '75x75c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/75x75c.jpg',
+                            '150x150':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150.jpg',
+                            '150x150c':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/150x150c.jpg',
+                            '300x300':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/300x300.jpg',
+                            '450x450':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/450x450.jpg',
+                            '800x800':'/files/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96/image/800x800.jpg'
+                        }
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('events', function () {
+        var getStub,
+            eventsSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            eventsSpy = sandbox.spy(namely, 'events');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.events(function () {});
+            });
+
+            it('it calls events and passes the correct arguments', function () {
+                expect(eventsSpy.calledOnce).toEqual(true);
+                expect(typeof(eventsSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/events');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.events({
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
+                }, function () {});
+            });
+
+            it('it calls events and passes the correct arguments', function () {
+                expect(eventsSpy.calledOnce).toEqual(true);
+                expect(eventsSpy.args[0][0]).toEqual({
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
                 });
             });
 
-            describe('no error', function () {
-                beforeEach(function () {
-                    stubs = {
-                        request: sandbox.stub().yields(null, {
-                            a: '1',
-                            b: '2',
-                            c: '3'
-                        }, {
-                            d: '4',
-                            e: '5',
-                            f: '6'
-                        })
-                    };
-
-                    Namely = proxyquire('..', stubs);
-
-                    namely = new Namely({
-                        accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
-                        companyName: 'companyName'
-                    });
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/events');
+                expect(getStub.args[0][1]).toEqual({
+                    body: {
+                        limit: 100,
+                        after: '12345678790'
+                    }
                 });
+                expect(typeof(getStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
 
-                it('calls callback with error if error returned', function () {
-                    namely.profiles({}, callbackSpy);
+    describe('event', function () {
+        var getStub,
+            eventSpy;
 
-                    expect(callbackSpy.calledOnce).toEqual(true);
-                    expect(callbackSpy.calledWith(null, {
-                        a: '1',
-                        b: '2',
-                        c: '3'
-                    }, {
-                        d: '4',
-                        e: '5',
-                        f: '6'
-                    })).toEqual(true);
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            eventSpy = sandbox.spy(namely, 'event');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.event('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
+            });
+
+            it('it calls event and passes the correct arguments', function () {
+                expect(eventSpy.calledOnce).toEqual(true);
+                expect(eventSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(eventSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/events/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('createEvent', function () {
+        var postStub,
+            createEventSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createEventSpy = sandbox.spy(namely, 'createEvent');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createEvent({
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                }, function () {});
+            });
+
+            it('it calls createEvent and passes the correct arguments', function () {
+                expect(createEventSpy.calledOnce).toEqual(true);
+                expect(createEventSpy.args[0][0]).toEqual({
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
                 });
+                expect(typeof(createEventSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/events');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateEvent', function () {
+        var putStub,
+            updateEventSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updateEventSpy = sandbox.spy(namely, 'updateEvent');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateEvent('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateEvent and passes the correct arguments', function () {
+                expect(updateEventSpy.calledOnce).toEqual(true);
+                expect(updateEventSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updateEventSpy.args[0][1]).toEqual({
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(updateEventSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/events/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        content: 'Content',
+                        file: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('currencyTypes', function () {
+        var getStub,
+            currencyTypesSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            currencyTypesSpy = sandbox.spy(namely, 'currencyTypes');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.currencyTypes(function () {});
+            });
+
+            it('it calls currencyTypes and passes the correct arguments', function () {
+                expect(currencyTypesSpy.calledOnce).toEqual(true);
+                expect(typeof(currencyTypesSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/currency_types');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('countries', function () {
+        var getStub,
+            countriesSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            countriesSpy = sandbox.spy(namely, 'countries');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.countries(function () {});
+            });
+
+            it('it calls countries and passes the correct arguments', function () {
+                expect(countriesSpy.calledOnce).toEqual(true);
+                expect(typeof(countriesSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/countries');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('country', function () {
+        var getStub,
+            countrySpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            countrySpy = sandbox.spy(namely, 'country');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.country('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
+            });
+
+            it('it calls country and passes the correct arguments', function () {
+                expect(countrySpy.calledOnce).toEqual(true);
+                expect(countrySpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(countrySpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/countries/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('jobTitles', function () {
+        var getStub,
+            jobTitlesSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            jobTitlesSpy = sandbox.spy(namely, 'jobTitles');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.jobTitles(function () {});
+            });
+
+            it('it calls jobTitles and passes the correct arguments', function () {
+                expect(jobTitlesSpy.calledOnce).toEqual(true);
+                expect(typeof(jobTitlesSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/job_titles');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('jobTitle', function () {
+        var getStub,
+            jobTitleSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            jobTitleSpy = sandbox.spy(namely, 'jobTitle');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.jobTitle('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
+            });
+
+            it('it calls jobTitle and passes the correct arguments', function () {
+                expect(jobTitleSpy.calledOnce).toEqual(true);
+                expect(jobTitleSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(jobTitleSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/job_titles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('createJobTitle', function () {
+        var postStub,
+            createJobTitleSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createJobTitleSpy = sandbox.spy(namely, 'createJobTitle');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createJobTitle({
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                }, function () {});
+            });
+
+            it('it calls createJobTitle and passes the correct arguments', function () {
+                expect(createJobTitleSpy.calledOnce).toEqual(true);
+                expect(createJobTitleSpy.args[0][0]).toEqual({
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(createJobTitleSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/job_titles');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateJobTitle', function () {
+        var putStub,
+            updateJobTitleSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updateJobTitleSpy = sandbox.spy(namely, 'updateJobTitle');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateJobTitle('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateJobTitle and passes the correct arguments', function () {
+                expect(updateJobTitleSpy.calledOnce).toEqual(true);
+                expect(updateJobTitleSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updateJobTitleSpy.args[0][1]).toEqual({
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(updateJobTitleSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/job_titles/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'job title',
+                        job_tier: 'd5b3cb26-8b17-4f18-9af7-f678fa6a2e96'
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('jobTiers', function () {
+        var getStub,
+            jobTiersSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            jobTiersSpy = sandbox.spy(namely, 'jobTiers');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.jobTiers(function () {});
+            });
+
+            it('it calls jobTiers and passes the correct arguments', function () {
+                expect(jobTiersSpy.calledOnce).toEqual(true);
+                expect(typeof(jobTiersSpy.args[0][0])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/job_tiers');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('jobTier', function () {
+        var getStub,
+            jobTierSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            getStub = sandbox.stub(namely, 'get');
+            jobTierSpy = sandbox.spy(namely, 'jobTier');
+        });
+
+        describe('with no options', function () {
+            beforeEach(function () {
+                namely.jobTier('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', function () {});
+            });
+
+            it('it calls jobTier and passes the correct arguments', function () {
+                expect(jobTierSpy.calledOnce).toEqual(true);
+                expect(jobTierSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(jobTierSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls get and passes the correct arguments', function () {
+                expect(getStub.calledOnce).toEqual(true);
+                expect(getStub.args[0][0]).toEqual('/job_tiers/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(typeof(getStub.args[0][1])).toEqual('function');
+                expect(getStub.args[0][2]).toEqual(undefined);
+            });
+        });
+    });
+
+    describe('createJobTier', function () {
+        var postStub,
+            createJobTierSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            postStub = sandbox.stub(namely, 'post');
+            createJobTierSpy = sandbox.spy(namely, 'createJobTier');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.createJobTier({
+                    body: {
+                        title: 'job tier'
+                    }
+                }, function () {});
+            });
+
+            it('it calls createJobTier and passes the correct arguments', function () {
+                expect(createJobTierSpy.calledOnce).toEqual(true);
+                expect(createJobTierSpy.args[0][0]).toEqual({
+                    body: {
+                        title: 'job tier'
+                    }
+                });
+                expect(typeof(createJobTierSpy.args[0][1])).toEqual('function');
+            });
+
+            it('it calls post and passes the correct arguments', function () {
+                expect(postStub.calledOnce).toEqual(true);
+                expect(postStub.args[0][0]).toEqual('/job_tiers');
+                expect(postStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'job tier'
+                    }
+                });
+                expect(typeof(postStub.args[0][2])).toEqual('function');
+            });
+        });
+    });
+
+    describe('updateJobTier', function () {
+        var putStub,
+            updateJobTierSpy;
+
+        beforeEach(function () {
+            namely = new Namely({
+                accessToken: 'UBLIJWQAPSONNTCLWQEFOZCCESLEJRVT',
+                companyName: 'companyName'
+            });
+
+            putStub = sandbox.stub(namely, 'put');
+            updateJobTierSpy = sandbox.spy(namely, 'updateJobTier');
+        });
+
+        describe('with options', function () {
+            beforeEach(function () {
+                namely.updateJobTier('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96', {
+                    body: {
+                        title: 'job tier'
+                    }
+                }, function () {});
+            });
+
+            it('it calls updateJobTier and passes the correct arguments', function () {
+                expect(updateJobTierSpy.calledOnce).toEqual(true);
+                expect(updateJobTierSpy.args[0][0]).toEqual('d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(updateJobTierSpy.args[0][1]).toEqual({
+                    body: {
+                        title: 'job tier'
+                    }
+                });
+                expect(typeof(updateJobTierSpy.args[0][2])).toEqual('function');
+            });
+
+            it('it calls put and passes the correct arguments', function () {
+                expect(putStub.calledOnce).toEqual(true);
+                expect(putStub.args[0][0]).toEqual('/job_tiers/d5b3cb26-8b17-4f18-9af7-f678fa6a2e96');
+                expect(putStub.args[0][1]).toEqual({
+                    body: {
+                        title: 'job tier'
+                    }
+                });
+                expect(typeof(putStub.args[0][2])).toEqual('function');
             });
         });
     });


### PR DESCRIPTION
## Changes
- Refactored index.js:
  - Use `request.defaults()` to set `json: true` globally
  - Modified `send` function to be private
  - Added `get`, `post`, and `put` request methods to create bridge between high level api requests and low level `send` function
  - Added check within request methods to check if `opts` is `cb` function
  - Now set full authorisation header and apiEndpoint path in `get`, `post` and `put` functions
- Added all api endpoints accept oauth
- Updated package.json
- Updated existing tests and ensured coverage of 100%
